### PR TITLE
Add support for doing upgrade using CALL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upgrade-executor",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "repository": "git@github.com:OffchainLabs/upgrade-executor.git",
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/UpgradeExecutor.sol
+++ b/src/UpgradeExecutor.sol
@@ -19,6 +19,9 @@ contract UpgradeExecutor is Initializable, AccessControlUpgradeable, ReentrancyG
     /// @notice Emitted when an upgrade execution occurs
     event UpgradeExecuted(address indexed upgrade, uint256 value, bytes data);
 
+    /// @notice Emitted when target call occurs
+    event TargetCallExecuted(address indexed target, uint256 value, bytes data);
+
     constructor() {
         _disableInitializers();
     }
@@ -58,19 +61,19 @@ contract UpgradeExecutor is Initializable, AccessControlUpgradeable, ReentrancyG
         emit UpgradeExecuted(upgrade, msg.value, upgradeCallData);
     }
 
-    /// @notice Execute an upgrade by directly calling an upgrade contract
+    /// @notice Execute an upgrade by directly calling target contract
     /// @dev    Only executor can call this.
-    function executeCall(address upgrade, bytes memory upgradeCallData)
+    function executeCall(address target, bytes memory targetCallData)
         public
         payable
         onlyRole(EXECUTOR_ROLE)
         nonReentrant
     {
         // OZ Address library check if the address is a contract and bubble up inner revert reason
-        address(upgrade).functionCallWithValue(
-            upgradeCallData, msg.value, "UpgradeExecutor: inner call failed without reason"
+        address(target).functionCallWithValue(
+            targetCallData, msg.value, "UpgradeExecutor: inner call failed without reason"
         );
 
-        emit UpgradeExecuted(upgrade, msg.value, upgradeCallData);
+        emit TargetCallExecuted(target, msg.value, targetCallData);
     }
 }

--- a/src/UpgradeExecutor.sol
+++ b/src/UpgradeExecutor.sol
@@ -57,4 +57,20 @@ contract UpgradeExecutor is Initializable, AccessControlUpgradeable, ReentrancyG
 
         emit UpgradeExecuted(upgrade, msg.value, upgradeCallData);
     }
+
+    /// @notice Execute an upgrade by directly calling an upgrade contract
+    /// @dev    Only executor can call this.
+    function executeCall(address upgrade, bytes memory upgradeCallData)
+        public
+        payable
+        onlyRole(EXECUTOR_ROLE)
+        nonReentrant
+    {
+        // OZ Address library check if the address is a contract and bubble up inner revert reason
+        address(upgrade).functionCallWithValue(
+            upgradeCallData, msg.value, "UpgradeExecutor: inner call failed without reason"
+        );
+
+        emit UpgradeExecuted(upgrade, msg.value, upgradeCallData);
+    }
 }


### PR DESCRIPTION
We have supported doing upgrades via executor using DELEGATECALL. This commit adds new entrypoint `executeCall` which does upgrade using CALL.